### PR TITLE
ブラウザの dark モード前提な配色を修正

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ const config = {
     colorMode: {
       defaultMode: 'dark',
       disableSwitch: true,
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     navbar: {
       title: 'Prototyping Blog',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,11 @@
     --ifm-color-primary-lightest: #4fddbf;
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+.hero__title {
+    color: white;
+}
+
+.hero__subtitle {
+    color: white;
+}


### PR DESCRIPTION
https://github.com/aws-samples/jp-prototyping-blog/issues/18

dark モードだけにして設定を尊重しないように変更しました。
ついでにタイトルとサブタイトルの色も変更しました。